### PR TITLE
feat(tui): pantalla de Setup para configurar entorno y claves GPG

### DIFF
--- a/crypto.py
+++ b/crypto.py
@@ -112,6 +112,18 @@ def list_secret_keys(gpg_home: Optional[str] = None) -> list[dict]:
     ]
 
 
+def export_public_key(keyid: str, gpg_home: Optional[str] = None) -> tuple[bool, str]:
+    """
+    Export the ASCII-armored public key for `keyid`.
+    Returns (success, armored_key_or_error).
+    """
+    gpg = _gpg(gpg_home)
+    armored = gpg.export_keys(keyid)
+    if not armored:
+        return False, f"No public key found for keyid: {keyid}"
+    return True, armored
+
+
 def list_public_keys(gpg_home: Optional[str] = None) -> list[dict]:
     """Return a list of available public keys in the keyring."""
     gpg = _gpg(gpg_home)

--- a/tui/screens/home.py
+++ b/tui/screens/home.py
@@ -13,6 +13,7 @@ class HomeScreen(Screen):
         ("1", "go_encrypt", "Cifrar"),
         ("2", "go_decrypt", "Descifrar"),
         ("3", "go_collaborators", "Colaboradores"),
+        ("s", "go_setup", "Configuración"),
         ("d", "toggle_dark", "Oscuro/Claro"),
         ("q", "quit_app", "Salir"),
     ]
@@ -27,6 +28,7 @@ class HomeScreen(Screen):
                     yield Button("1  Cifrar mensaje", id="btn-encrypt", variant="primary")
                     yield Button("2  Descifrar mensaje", id="btn-decrypt")
                     yield Button("3  Colaboradores", id="btn-collaborators")
+                    yield Button("S  Configuración", id="btn-setup", variant="warning")
                     yield Button("Q  Salir", id="btn-quit", variant="error")
         yield Footer()
 
@@ -43,6 +45,8 @@ class HomeScreen(Screen):
                 self.action_go_decrypt()
             case "btn-collaborators":
                 self.action_go_collaborators()
+            case "btn-setup":
+                self.action_go_setup()
             case "btn-quit":
                 self.action_quit_app()
 
@@ -57,6 +61,10 @@ class HomeScreen(Screen):
     def action_go_collaborators(self) -> None:
         from gpgshare.tui.screens.collaborators import CollaboratorsScreen
         self.app.push_screen(CollaboratorsScreen())
+
+    def action_go_setup(self) -> None:
+        from gpgshare.tui.screens.setup import SetupScreen
+        self.app.push_screen(SetupScreen())
 
     def action_toggle_dark(self) -> None:
         self.app.action_toggle_dark()

--- a/tui/screens/setup.py
+++ b/tui/screens/setup.py
@@ -1,25 +1,26 @@
 """
 SetupScreen — formulario para configurar .env desde la TUI.
-Closes #1
+Closes #1, #2
 """
 
 import os
 from pathlib import Path
 from textual.app import ComposeResult
 from textual.screen import Screen
-from textual.widgets import Header, Footer, Button, Input, Label, Static
+from textual.widgets import Header, Footer, Button, Input, Label, Static, Select
 from textual.containers import Vertical, ScrollableContainer
+from textual import work
 
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _ENV_PATH = _PROJECT_ROOT / ".env"
 
 _FIELDS = [
-    ("GPG_SIGNER_EMAIL",      "Email del firmante (requerido)",          False, False),
-    ("GPG_PRIVATE_KEY_PATH",  "Ruta a la clave privada .asc (requerido)", False, False),
-    ("GPG_HOME",              "Directorio GPG (opcional, default ~/.gnupg)", True, False),
-    ("KEYS_DIR",              "Directorio de claves públicas (opcional)", True, False),
-    ("COLLABORATORS_FILE",    "Archivo de colaboradores (opcional)",      True, False),
+    ("GPG_SIGNER_EMAIL",      "Email del firmante (requerido)",             False),
+    ("GPG_PRIVATE_KEY_PATH",  "Ruta a la clave privada .asc (requerido)",   False),
+    ("GPG_HOME",              "Directorio GPG (opcional, default ~/.gnupg)", True),
+    ("KEYS_DIR",              "Directorio de claves públicas (opcional)",    True),
+    ("COLLABORATORS_FILE",    "Archivo de colaboradores (opcional)",         True),
 ]
 
 
@@ -37,29 +38,37 @@ def _read_env() -> dict[str, str]:
 
 
 def _write_env(values: dict[str, str]) -> None:
-    lines = []
-    for key, val in values.items():
-        lines.append(f"{key}={val}")
+    lines = [f"{k}={v}" for k, v in values.items()]
     _ENV_PATH.write_text("\n".join(lines) + "\n")
+
+
+def _canonical_filename(email: str) -> str:
+    return email.lower().replace("@", "-").replace(".", "-") + ".asc"
+
+
+def _uid_label(uid: str) -> str:
+    """Return 'Name <email>' or the raw uid string."""
+    return uid if uid else "(sin identificador)"
 
 
 class SetupScreen(Screen):
     BINDINGS = [
         ("escape", "go_back", "Volver"),
-        ("ctrl+s", "save", "Guardar"),
+        ("ctrl+s", "save", "Guardar config"),
     ]
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         with ScrollableContainer():
             with Vertical(id="setup-container"):
+                # ── Sección 1: .env ──────────────────────────────────────
                 yield Static("Configuración del entorno", id="setup-title")
                 yield Static(
                     "Los campos requeridos se guardan en el archivo .env del proyecto.",
                     id="setup-subtitle",
                 )
                 current = _read_env()
-                for key, label, optional, _ in _FIELDS:
+                for key, label, optional in _FIELDS:
                     yield Label(
                         f"{label}{' *' if not optional else ''}",
                         classes="form-label",
@@ -70,10 +79,62 @@ class SetupScreen(Screen):
                         id=f"input-{key}",
                     )
                 with Vertical(classes="form-actions"):
-                    yield Button("Guardar", id="btn-save", variant="success")
+                    yield Button("Guardar configuración", id="btn-save", variant="success")
                     yield Button("Cancelar", id="btn-cancel")
-                yield Static("", id="setup-status")  # errores de validación
+                yield Static("", id="setup-status")
+
+                # ── Sección 2: Registrar mi clave pública ────────────────
+                yield Static("Registrar mi clave pública", id="register-title")
+                yield Static(
+                    "Exporta tu clave pública al directorio keys/ y te registra como colaborador.",
+                    id="register-subtitle",
+                )
+                yield Label("Seleccionar clave GPG *", classes="form-label")
+                yield Select(
+                    options=[],
+                    prompt="Cargando claves...",
+                    id="select-key",
+                    allow_blank=True,
+                )
+                yield Label("Alias (tu nombre en el registro) *", classes="form-label")
+                yield Input(placeholder="ej: juan", id="input-alias")
+                with Vertical(classes="form-actions"):
+                    yield Button("Registrar mi clave", id="btn-register", variant="primary")
+                yield Static("", id="register-status")
+
         yield Footer()
+
+    def on_mount(self) -> None:
+        self._load_keys()
+
+    @work(thread=True)
+    def _load_keys(self) -> None:
+        from gpgshare.crypto import list_secret_keys
+        cfg = getattr(self.app, "_cfg", None)
+        gpg_home = cfg.gpg_home if cfg else None
+        keys = list_secret_keys(gpg_home)
+        self.app.call_from_thread(self._populate_select, keys)
+
+    def _populate_select(self, keys: list[dict]) -> None:
+        select: Select = self.query_one("#select-key", Select)
+        cfg = getattr(self.app, "_cfg", None)
+        signer_email = cfg.signer_email if cfg else _read_env().get("GPG_SIGNER_EMAIL", "")
+
+        options = []
+        preselect = None
+        for k in keys:
+            label = k["uids"][0] if k["uids"] else k["keyid"]
+            options.append((label, k["keyid"]))
+            if signer_email and any(signer_email.lower() in uid.lower() for uid in k["uids"]):
+                preselect = k["keyid"]
+
+        if not options:
+            select.set_options([("No se encontraron claves secretas en el keyring", "")])
+            return
+
+        select.set_options(options)
+        if preselect:
+            select.value = preselect
 
     def action_go_back(self) -> None:
         self.app.pop_screen()
@@ -82,16 +143,19 @@ class SetupScreen(Screen):
         self._do_save()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "btn-save":
-            self._do_save()
-        elif event.button.id == "btn-cancel":
-            self.action_go_back()
+        match event.button.id:
+            case "btn-save":
+                self._do_save()
+            case "btn-cancel":
+                self.action_go_back()
+            case "btn-register":
+                self._do_register()
 
     def _do_save(self) -> None:
         values: dict[str, str] = {}
         missing = []
 
-        for key, _, optional, _ in _FIELDS:
+        for key, _, optional in _FIELDS:
             widget: Input = self.query_one(f"#input-{key}", Input)
             val = widget.value.strip()
             if val:
@@ -107,10 +171,81 @@ class SetupScreen(Screen):
 
         try:
             _write_env(values)
-            # Recargar variables de entorno en el proceso actual
             for key, val in values.items():
                 os.environ[key] = val
             self.notify("Configuración guardada correctamente.", severity="information", title="Setup")
             self.app.pop_screen()
         except OSError as exc:
             status.update(f"[red]Error al guardar: {exc}[/red]")
+
+    def _do_register(self) -> None:
+        select: Select = self.query_one("#select-key", Select)
+        alias_input: Input = self.query_one("#input-alias", Input)
+        status = self.query_one("#register-status", Static)
+
+        keyid = select.value
+        alias = alias_input.value.strip()
+
+        if not keyid or keyid is Select.BLANK:
+            status.update("[red]Seleccioná una clave GPG.[/red]")
+            return
+        if not alias:
+            status.update("[red]El alias es requerido.[/red]")
+            return
+
+        # Obtener el email del uid seleccionado
+        uid_label = str(select._options[  # buscar label del valor seleccionado
+            next(i for i, (_, v) in enumerate(select._options) if v == keyid)
+        ][0]) if hasattr(select, "_options") else ""
+
+        # Extraer email del uid (formato "Name <email@domain.com>")
+        import re
+        match = re.search(r"<(.+?)>", uid_label)
+        email = match.group(1) if match else uid_label
+
+        status.update("[yellow]Registrando...[/yellow]")
+        self._run_register(keyid, alias, email)
+
+    @work(thread=True)
+    def _run_register(self, keyid: str, alias: str, email: str) -> None:
+        from gpgshare.crypto import export_public_key
+        from gpgshare.collaborators import add_collaborator, find_by_email, find_by_alias
+
+        cfg = getattr(self.app, "_cfg", None)
+        gpg_home = cfg.gpg_home if cfg else None
+
+        if cfg:
+            keys_dir = cfg.keys_dir
+            collaborators_file = cfg.collaborators_file
+        else:
+            env = _read_env()
+            keys_dir = Path(env.get("KEYS_DIR", str(_PROJECT_ROOT / "keys")))
+            collaborators_file = Path(env.get("COLLABORATORS_FILE", str(_PROJECT_ROOT / "collaborators.yaml")))
+
+        ok, result = export_public_key(keyid, gpg_home)
+        if not ok:
+            self.app.call_from_thread(self._set_register_status, f"[red]Error al exportar clave: {result}[/red]")
+            return
+
+        filename = _canonical_filename(email)
+        key_path = keys_dir / filename
+        try:
+            keys_dir.mkdir(parents=True, exist_ok=True)
+            key_path.write_text(result)
+        except OSError as exc:
+            self.app.call_from_thread(self._set_register_status, f"[red]Error al escribir {filename}: {exc}[/red]")
+            return
+
+        try:
+            add_collaborator(collaborators_file, alias, email, filename)
+        except ValueError as exc:
+            self.app.call_from_thread(self._set_register_status, f"[red]{exc}[/red]")
+            return
+
+        self.app.call_from_thread(
+            self._set_register_status,
+            f"[green]Clave registrada como '{alias}' ({email}) → keys/{filename}[/green]",
+        )
+
+    def _set_register_status(self, msg: str) -> None:
+        self.query_one("#register-status", Static).update(msg)

--- a/tui/screens/setup.py
+++ b/tui/screens/setup.py
@@ -1,6 +1,6 @@
 """
 SetupScreen — formulario para configurar .env desde la TUI.
-Closes #1, #2
+Closes #1, #2, #3
 """
 
 import os
@@ -10,6 +10,7 @@ from textual.screen import Screen
 from textual.widgets import Header, Footer, Button, Input, Label, Static, Select
 from textual.containers import Vertical, ScrollableContainer
 from textual import work
+from gpgshare.tui.widgets.cipher_output import CipherOutput
 
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -102,6 +103,23 @@ class SetupScreen(Screen):
                     yield Button("Registrar mi clave", id="btn-register", variant="primary")
                 yield Static("", id="register-status")
 
+                # ── Sección 3: Exportar mi clave pública ─────────────────
+                yield Static("Exportar mi clave pública", id="export-title")
+                yield Static(
+                    "Obtené tu clave pública para compartir con otros colaboradores.",
+                    id="export-subtitle",
+                )
+                yield Label("Seleccionar clave GPG *", classes="form-label")
+                yield Select(
+                    options=[],
+                    prompt="Cargando claves...",
+                    id="select-key-export",
+                    allow_blank=True,
+                )
+                with Vertical(classes="form-actions"):
+                    yield Button("Exportar", id="btn-export", variant="primary")
+                yield CipherOutput(title="Clave pública", id="export-output")
+
         yield Footer()
 
     def on_mount(self) -> None:
@@ -116,7 +134,6 @@ class SetupScreen(Screen):
         self.app.call_from_thread(self._populate_select, keys)
 
     def _populate_select(self, keys: list[dict]) -> None:
-        select: Select = self.query_one("#select-key", Select)
         cfg = getattr(self.app, "_cfg", None)
         signer_email = cfg.signer_email if cfg else _read_env().get("GPG_SIGNER_EMAIL", "")
 
@@ -128,13 +145,16 @@ class SetupScreen(Screen):
             if signer_email and any(signer_email.lower() in uid.lower() for uid in k["uids"]):
                 preselect = k["keyid"]
 
-        if not options:
-            select.set_options([("No se encontraron claves secretas en el keyring", "")])
-            return
+        empty_opts = [("No se encontraron claves secretas en el keyring", "")]
 
-        select.set_options(options)
-        if preselect:
-            select.value = preselect
+        for sel_id in ("#select-key", "#select-key-export"):
+            select: Select = self.query_one(sel_id, Select)
+            if not options:
+                select.set_options(empty_opts)
+            else:
+                select.set_options(options)
+                if preselect:
+                    select.value = preselect
 
     def action_go_back(self) -> None:
         self.app.pop_screen()
@@ -150,6 +170,8 @@ class SetupScreen(Screen):
                 self.action_go_back()
             case "btn-register":
                 self._do_register()
+            case "btn-export":
+                self._do_export()
 
     def _do_save(self) -> None:
         values: dict[str, str] = {}
@@ -249,3 +271,27 @@ class SetupScreen(Screen):
 
     def _set_register_status(self, msg: str) -> None:
         self.query_one("#register-status", Static).update(msg)
+
+    def _do_export(self) -> None:
+        select: Select = self.query_one("#select-key-export", Select)
+        keyid = select.value
+        if not keyid or keyid is Select.BLANK:
+            self.notify("Seleccioná una clave GPG.", severity="warning")
+            return
+        self._run_export(keyid)
+
+    @work(thread=True)
+    def _run_export(self, keyid: str) -> None:
+        from gpgshare.crypto import export_public_key
+        cfg = getattr(self.app, "_cfg", None)
+        gpg_home = cfg.gpg_home if cfg else None
+        ok, result = export_public_key(keyid, gpg_home)
+        if not ok:
+            self.app.call_from_thread(
+                self.notify, f"Error al exportar clave: {result}", severity="error"
+            )
+            return
+        self.app.call_from_thread(self._show_export, result)
+
+    def _show_export(self, armored: str) -> None:
+        self.query_one("#export-output", CipherOutput).set_content(armored)

--- a/tui/screens/setup.py
+++ b/tui/screens/setup.py
@@ -1,0 +1,116 @@
+"""
+SetupScreen — formulario para configurar .env desde la TUI.
+Closes #1
+"""
+
+import os
+from pathlib import Path
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Header, Footer, Button, Input, Label, Static
+from textual.containers import Vertical, ScrollableContainer
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_ENV_PATH = _PROJECT_ROOT / ".env"
+
+_FIELDS = [
+    ("GPG_SIGNER_EMAIL",      "Email del firmante (requerido)",          False, False),
+    ("GPG_PRIVATE_KEY_PATH",  "Ruta a la clave privada .asc (requerido)", False, False),
+    ("GPG_HOME",              "Directorio GPG (opcional, default ~/.gnupg)", True, False),
+    ("KEYS_DIR",              "Directorio de claves públicas (opcional)", True, False),
+    ("COLLABORATORS_FILE",    "Archivo de colaboradores (opcional)",      True, False),
+]
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not _ENV_PATH.exists():
+        return values
+    for line in _ENV_PATH.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip()
+    return values
+
+
+def _write_env(values: dict[str, str]) -> None:
+    lines = []
+    for key, val in values.items():
+        lines.append(f"{key}={val}")
+    _ENV_PATH.write_text("\n".join(lines) + "\n")
+
+
+class SetupScreen(Screen):
+    BINDINGS = [
+        ("escape", "go_back", "Volver"),
+        ("ctrl+s", "save", "Guardar"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with ScrollableContainer():
+            with Vertical(id="setup-container"):
+                yield Static("Configuración del entorno", id="setup-title")
+                yield Static(
+                    "Los campos requeridos se guardan en el archivo .env del proyecto.",
+                    id="setup-subtitle",
+                )
+                current = _read_env()
+                for key, label, optional, _ in _FIELDS:
+                    yield Label(
+                        f"{label}{' *' if not optional else ''}",
+                        classes="form-label",
+                    )
+                    yield Input(
+                        value=current.get(key, ""),
+                        placeholder=key,
+                        id=f"input-{key}",
+                    )
+                with Vertical(classes="form-actions"):
+                    yield Button("Guardar", id="btn-save", variant="success")
+                    yield Button("Cancelar", id="btn-cancel")
+                yield Static("", id="setup-status")  # errores de validación
+        yield Footer()
+
+    def action_go_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_save(self) -> None:
+        self._do_save()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-save":
+            self._do_save()
+        elif event.button.id == "btn-cancel":
+            self.action_go_back()
+
+    def _do_save(self) -> None:
+        values: dict[str, str] = {}
+        missing = []
+
+        for key, _, optional, _ in _FIELDS:
+            widget: Input = self.query_one(f"#input-{key}", Input)
+            val = widget.value.strip()
+            if val:
+                values[key] = val
+            elif not optional:
+                missing.append(key)
+
+        status = self.query_one("#setup-status", Static)
+
+        if missing:
+            status.update(f"[red]Faltan campos requeridos: {', '.join(missing)}[/red]")
+            return
+
+        try:
+            _write_env(values)
+            # Recargar variables de entorno en el proceso actual
+            for key, val in values.items():
+                os.environ[key] = val
+            self.notify("Configuración guardada correctamente.", severity="information", title="Setup")
+            self.app.pop_screen()
+        except OSError as exc:
+            status.update(f"[red]Error al guardar: {exc}[/red]")

--- a/tui/styles/app.tcss
+++ b/tui/styles/app.tcss
@@ -185,3 +185,33 @@ AddCollaboratorModal {
 #loading-overlay.visible {
     display: block;
 }
+
+/* ── Setup ───────────────────────────────────────────────── */
+
+#setup-container {
+    width: 60;
+    height: auto;
+    padding: 1 2;
+    border: round $warning;
+    margin: 1 0;
+}
+
+#setup-title {
+    text-style: bold;
+    color: $warning;
+    text-align: center;
+    padding: 1 0;
+    width: 100%;
+}
+
+#setup-subtitle {
+    color: $muted;
+    text-align: center;
+    padding: 0 0 1 0;
+    width: 100%;
+}
+
+#setup-status {
+    padding: 1 0;
+    height: auto;
+}

--- a/tui/styles/app.tcss
+++ b/tui/styles/app.tcss
@@ -233,3 +233,16 @@ AddCollaboratorModal {
     padding: 1 0;
     height: auto;
 }
+
+#export-title {
+    text-style: bold;
+    color: $primary;
+    padding: 2 0 0 0;
+    width: 100%;
+}
+
+#export-subtitle {
+    color: $muted;
+    padding: 0 0 1 0;
+    width: 100%;
+}

--- a/tui/styles/app.tcss
+++ b/tui/styles/app.tcss
@@ -215,3 +215,21 @@ AddCollaboratorModal {
     padding: 1 0;
     height: auto;
 }
+
+#register-title {
+    text-style: bold;
+    color: $primary;
+    padding: 2 0 0 0;
+    width: 100%;
+}
+
+#register-subtitle {
+    color: $muted;
+    padding: 0 0 1 0;
+    width: 100%;
+}
+
+#register-status {
+    padding: 1 0;
+    height: auto;
+}


### PR DESCRIPTION
## Summary

- Agrega `SetupScreen` accesible desde el menú principal (tecla `S`) con tres secciones:
  - **Configurar `.env`**: formulario que pre-popula valores existentes, valida campos requeridos y escribe el archivo al guardar
  - **Registrar mi clave pública**: lista las claves secretas del keyring GPG, pre-selecciona la del firmante configurado, exporta la clave pública a `keys/` y la registra en `collaborators.yaml`
  - **Exportar mi clave pública**: exporta la clave seleccionada en formato ASCII armored con opciones para copiar al portapapeles o guardar a archivo (reutiliza `CipherOutput`)
- Agrega `export_public_key(keyid, gpg_home)` en `crypto.py`
- Las operaciones GPG corren en workers de thread para no bloquear el event loop

## Test plan

- [ ] Entrar al Setup desde el menú con `S` o el botón
- [ ] Verificar que los campos del `.env` se pre-populan si el archivo existe
- [ ] Guardar configuración y confirmar que vuelve al menú con notificación
- [ ] Verificar que el Select de claves GPG pre-selecciona la del firmante configurado
- [ ] Registrar propia clave y verificar que aparece en `collaborators.yaml` y `keys/`
- [ ] Exportar clave pública y copiar al portapapeles / guardar a archivo

Closes #1, #2, #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)